### PR TITLE
Fix select height on image size

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -136,7 +136,7 @@ button:hover {
 }
 
 .select-wrapper.small {
-    height: 24px;
+    height: 30px;
     min-width: 100px;
     width: 100px;
 }


### PR DESCRIPTION
Hi guys, great work!
First fresh PR 😬
On my iPhone 11 Pro the select fields of the image size don't fit in well.

![2020-11-02 21 43 49](https://user-images.githubusercontent.com/4376886/97918308-38118f80-1d56-11eb-932a-b2a0fadf2214.png)
