### PR TITLE
Allowed package information to be optional

### DIFF
--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -90,6 +90,19 @@ function getDescription(description: string) {
     `
 }
 
+function getPackageInformation(packageManager: string, packageName: string) {
+    if (
+        (packageManager === '' || packageManager === undefined) && 
+        (packageName === '' || packageName === undefined)
+    ) {
+        return '';
+    }
+
+    return `
+    <code>${sanitizeHtml(packageManager)} ${sanitizeHtml(packageName)}</code>
+    `
+}
+
 function getAlternativeHtml(parsedReq: ParsedRequest) {
     const { text, theme, md, fontSize, images, widths, heights, pattern, packageManager, packageName, description, style, showWatermark } = parsedReq;
 
@@ -116,7 +129,7 @@ function getAlternativeHtml(parsedReq: ParsedRequest) {
     )}
             </div>
             ${getDescription(description)}
-            <code>${sanitizeHtml(packageManager)} ${sanitizeHtml(packageName)}</code>
+            ${getPackageInformation(packageManager, packageName)}
         </div>
         ${showWatermark ? getWatermark(theme) : ''}
     </body>
@@ -163,7 +176,7 @@ export function getHtml(parsedReq: ParsedRequest) {
             )}
             </div>
             ${getDescription(description)}
-            <code>${sanitizeHtml(packageManager)} ${sanitizeHtml(packageName)}</code>
+            ${getPackageInformation(packageManager, packageName)}
             ${showWatermark ? getWatermark(theme) : ''}
         </div>
     </body>

--- a/web/index.ts
+++ b/web/index.ts
@@ -117,6 +117,7 @@ const packageManagerOptions: DropdownOption[] = [
     {text: 'Node/NPM', value: 'npm install'},
     {text: 'Node/Yarn', value: 'yarn add'},
     {text: 'Python/pip', value: 'pip install'},
+    {text: 'No Package Manager', value: ''},
 ];
 
 const themeOptions: DropdownOption[] = [


### PR DESCRIPTION
The dropdown for package mangers has been updated to have a no package
manager option.

The template has been updated to pass the package manager and package name
to a function and only display the block if both are present.