### PR TITLE
Trim leading whitespace w/o packageManager

### DIFF
--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -98,8 +98,10 @@ function getPackageInformation(packageManager: string, packageName: string) {
         return '';
     }
 
+    const packageInformation: string = `${sanitizeHtml(packageManager)} ${sanitizeHtml(packageName)}`.trim();
+
     return `
-    <code>${sanitizeHtml(packageManager)} ${sanitizeHtml(packageName)}</code>
+    <code>${packageInformation}</code>
     `
 }
 


### PR DESCRIPTION
When no package manager is provided there is a leading whitespace which looks odd.
This PR fixes this behavior by trimming whitespaces.

Resolves #13 