### PR TITLE
add support for Golang as a `Package Manager`

### DIFF
--- a/web/index.ts
+++ b/web/index.ts
@@ -117,6 +117,7 @@ const packageManagerOptions: DropdownOption[] = [
     {text: 'Node/NPM', value: 'npm install'},
     {text: 'Node/Yarn', value: 'yarn add'},
     {text: 'Python/pip', value: 'pip install'},
+    {text: 'Golang', value: 'go install'},
     {text: 'No Package Manager', value: ''},
 ];
 


### PR DESCRIPTION
### What's Changed

Adds support for `Golang` as a Package Manager type.

![image](https://user-images.githubusercontent.com/1443700/139530307-39dbaed0-c55b-4904-9a5c-46a3c20a9feb.png)

relates to:
- #12 

### Technical Description

Whilst trying to use `banners` to create a banner for a `Go` repository - I noticed there was no option to select `Golang`.

When selecting `No Package Manager` this introduced a leading space before the install command.

![magic-home](https://user-images.githubusercontent.com/1443700/139530286-ca80235c-ef31-40e7-a2ab-0c05b278b4a9.png)


